### PR TITLE
Minor fix typo in `dtype_memory_size_dict`

### DIFF
--- a/gpu_mem_track.py
+++ b/gpu_mem_track.py
@@ -6,20 +6,20 @@ import torch
 import numpy as np
 
 dtype_memory_size_dict = {
-    torch.float: 32 / 8,
-    torch.float32: 32 / 8,
-    torch.float16: 16 / 8,
-    torch.half: 16 / 8,
     torch.float64: 64 / 8,
     torch.double: 64 / 8,
-    torch.uint8: 8 / 8,
-    torch.int: 32 / 8,
-    torch.int32: 32 / 8,
-    torch.int8: 8 / 8,
-    torch.int16: 16 / 8,
-    torch.short: 16 / 8,
+    torch.float32: 32 / 8,
+    torch.float: 32 / 8,
+    torch.float16: 16 / 8,
+    torch.half: 16 / 8,
     torch.int64: 64 / 8,
     torch.long: 64 / 8,
+    torch.int32: 32 / 8,
+    torch.int: 32 / 8,
+    torch.int16: 16 / 8,
+    torch.short: 16 / 8,
+    torch.uint8: 8 / 8,
+    torch.int8: 8 / 8,
 }
 # compatibility of torch1.0
 if getattr(torch, "bfloat16", None) is not None:

--- a/gpu_mem_track.py
+++ b/gpu_mem_track.py
@@ -6,20 +6,20 @@ import torch
 import numpy as np
 
 dtype_memory_size_dict = {
-    torch.float64: 64/8,
-    torch.double: 64/8,
-    torch.float32: 32/8,
-    torch.float: 32/8,
-    torch.float16: 16/8,
-    torch.half: 16/8,
-    torch.int64: 64/8,
-    torch.long: 64/8,
-    torch.int32: 32/8,
-    torch.int: 32/8,
-    torch.int16: 16/8,
-    torch.short: 16/6,
-    torch.uint8: 8/8,
-    torch.int8: 8/8,
+    torch.float: 32 / 8,
+    torch.float32: 32 / 8,
+    torch.float16: 16 / 8,
+    torch.half: 16 / 8,
+    torch.float64: 64 / 8,
+    torch.double: 64 / 8,
+    torch.uint8: 8 / 8,
+    torch.int: 32 / 8,
+    torch.int32: 32 / 8,
+    torch.int8: 8 / 8,
+    torch.int16: 16 / 8,
+    torch.short: 16 / 8,
+    torch.int64: 64 / 8,
+    torch.long: 64 / 8,
 }
 # compatibility of torch1.0
 if getattr(torch, "bfloat16", None) is not None:


### PR DESCRIPTION
Dear maintainers:

In `dtype_memory_size_dict`, there was `torch.short: 16/6`,
so I modified it to `torch.short: 16 / 8`.
Would you mind checking this?

Thank you very much.

안녕하세요,

`dtype_memory_size_dict`에 `torch.short: 16/6`라 쓰인 부분을,
int16인 경우와 맞추어서 `torch.short: 16 / 8`로 수정했습니다.
제가 식견이 부족한지라, 해당 값이 의도된 것인지 아닌지 판단을 할 다를 근거가 없었기 때문에...
한번 살펴봐주시고, 혹여 괜찮으시면 merge를 부탁드립니다.

읽어주셔서 감사합니다.
